### PR TITLE
Logstash 5.x compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
+## 0.9.1
+ - Rubocop cleanup
+ - Logstash 5 compatible
+ - Add Dockerfile to have POC running
+
 ## 0.9.0
  - Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM logstash:5
+
+MAINTAINER Sergey Melnik <sergey.melnik@commercetools.com>
+
+ENV PATH=/usr/share/logstash/vendor/jruby/bin/:$PATH
+
+COPY ./ /opt/logstash-plugin
+
+RUN cd /opt/logstash-plugin/ && gem build logstash-input-google_pubsub.gemspec
+
+RUN logstash-plugin install /opt/logstash-plugin/logstash-input-google_pubsub-0.9.1.gem

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ bundle exec rspec
 
 - Edit Logstash `Gemfile` and add the local plugin path, for example:
 ```ruby
-gem "logstash-filter-awesome", :path => "/your/local/logstash-filter-awesome"
+gem "logstash-input-google_pubsub", :path => "/your/local/logstash-input-google_pubsub"
 ```
 - Install plugin
 ```sh
@@ -175,7 +175,7 @@ You can use the same **2.1** method to run your plugin in an installed Logstash 
 
 - Build your plugin gem
 ```sh
-gem build logstash-filter-awesome.gemspec
+gem build logstash-input-google_pubsub.gemspec
 ```
 - Install the plugin from the Logstash home
 ```sh

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require "logstash/devutils/rake"
+require 'logstash/devutils/rake'

--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -48,7 +48,7 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
   private
 
   def request(options)
-    @logger.info('Sending an API request')
+    @logger.debug('Sending an API request')
     @client.execute(options)
   rescue ArgumentError => _e
     @logger.info('Authorizing...')

--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -16,65 +16,63 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-require "logstash/inputs/base"
-require "logstash/namespace"
+require 'logstash/inputs/base'
+require 'logstash/namespace'
 
 # Google deps
-require "google/api_client"
+require 'google/api_client'
 
-# Generate a repeating message.
-#
-# This plugin is intented only as an example.
-
+# Collect messages from google pubsub
 class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
-  config_name "google_pubsub"
+  config_name 'google_pubsub'
 
   # Google Cloud Project ID (name, not number)
-  config :project_id, :validate => :string, :required => true
+  config :project_id, validate: :string, required: true
 
   # Google Cloud Pub/Sub Topic and Subscription.
   # Note that the topic must be created manually with Cloud Logging
   # pre-configured export to PubSub configured to use the defined topic.
   # The subscription will be created automatically by the plugin.
-  config :topic, :validate => :string, :required => true
-  config :subscription, :validate => :string, :required => true
-  config :max_messages, :validate => :number, :required => true, :default => 5
+  config :topic, validate: :string, required: true
+  config :subscription, validate: :string, required: true
+  config :max_messages, validate: :number, required: true, default: 5
 
   # If logstash is running within Google Compute Engine, the plugin will use
   # GCE's Application Default Credentials. Outside of GCE, you will need to
   # specify a Service Account JSON key file.
-  config :json_key_file, :validate => :path, :required => false
+  config :json_key_file, validate: :path, required: false
 
   # If undefined, Logstash will complain, even if codec is unused.
-  default :codec, "plain"
+  default :codec, 'plain'
 
   private
+
   def request(options)
-    begin
-      @logger.info("Sending an API request")
-      result = @client.execute(options)
-    rescue ArgumentError => e
-      @logger.info("Authorizing...")
-      @client.authorization.fetch_access_token!
-      @logger.info("...authorized")
-      request(options)
-    rescue Faraday::TimeoutError => e
-      @logger.info("Request timeout, re-trying request")
-      request(options)
-    end
+    @logger.info('Sending an API request')
+    @client.execute(options)
+  rescue ArgumentError => _e
+    @logger.info('Authorizing...')
+    @client.authorization.fetch_access_token!
+    @logger.info('...authorized')
+    request(options)
+  rescue Faraday::TimeoutError => _e
+    @logger.info('Request timeout, re-trying request')
+    request(options)
   end # def request
 
   public
+
   def register
-    @logger.info("Registering Google PubSub Input: project_id=#{@project_id}, topic=#{@topic}, subscription=#{@subscription}")
+    @logger.info("Registering Google PubSub Input: project_id=#{@project_id},
+      topic=#{@topic}, subscription=#{@subscription}")
     @topic = "projects/#{@project_id}/topics/#{@topic}"
     @subscription = "projects/#{@project_id}/subscriptions/#{@subscription}"
     @subscription_exists = false
 
     # TODO(erjohnso): read UA data from the gemspec
     @client = Google::APIClient.new(
-      :application_name => 'logstash-input-google_pubsub',
-      :application_version => '0.9.0'
+      application_name: 'logstash-input-google_pubsub',
+      application_version: '0.9.1'
     )
 
     # Initialize the pubsub API client
@@ -88,98 +86,98 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
     if @json_key_file
       @logger.info("Authorizing with JSON key file: #{@json_key_file}")
       file_path = File.expand_path(@json_key_file)
-      key_json = File.open(file_path, "r", &:read)
+      key_json = File.open(file_path, 'r', &:read)
       key_json = JSON.parse(key_json)
-      unless key_json.key?("client_email") || key_json.key?("private_key")
-        raise Google::APIClient::ClientError, "Invalid JSON credentials data."
+      unless key_json.key?('client_email') || key_json.key?('private_key')
+        raise Google::APIClient::ClientError, 'Invalid JSON credentials data.'
       end
-      signing_key = ::Google::APIClient::KeyUtils.load_from_pem(key_json["private_key"], "notasecret")
+      signing_key = ::Google::APIClient::KeyUtils.load_from_pem(key_json['private_key'], 'notasecret')
       @client.authorization = Signet::OAuth2::Client.new(
-        :audience => "https://accounts.google.com/o/oauth2/token",
-        :auth_provider_x509_cert_url => "https://www.googleapis.com/oauth2/v1/certs",
-        :client_x509_cert_url => "https://www.googleapis.com/robot/v1/metadata/x509/#{key_json['client_email']}",
-        :issuer => "#{key_json['client_email']}",
-        :scope => %w(https://www.googleapis.com/auth/cloud-platform),
-        :signing_key => signing_key,
-        :token_credential_uri => "https://accounts.google.com/o/oauth2/token"
+        audience: 'https://accounts.google.com/o/oauth2/token',
+        auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
+        client_x509_cert_url: "https://www.googleapis.com/robot/v1/metadata/x509/#{key_json['client_email']}",
+        issuer: (key_json['client_email']).to_s,
+        scope: %w(https://www.googleapis.com/auth/cloud-platform),
+        signing_key: signing_key,
+        token_credential_uri: 'https://accounts.google.com/o/oauth2/token'
       )
-      @logger.info("Client authorizataion with JSON key ready")
+      @logger.info('Client authorizataion with JSON key ready')
     else
       # Assume we're running in GCE and can use metadata tokens, if the host
       # GCE instance was not created with the PubSub scope, then the plugin
       # will not be authorized to read from pubsub.
-      @logger.info("Authorizing with application default credentials")
+      @logger.info('Authorizing with application default credentials')
       @client.authorization = :google_app_default
     end # if @json_key_file...
   end # def register
 
+  def create_subscription
+    @logger.info("Creating subscription #{subscription}")
+    result = request(
+      api_method: @pubsub.projects.subscriptions.create,
+      parameters: { 'name' => @subscription },
+      body_object: { topic: @topic, ackDeadlineSeconds: 15 }
+    )
+    if result.error? && result.status != 409
+      raise Google::APIClient::ClientError, "Error #{result.status}: #{result.error_message}"
+    end
+    @subscription_exists = true
+  end
+
   def run(queue)
     # Attempt to create the subscription
-    if !@subscription_exists
-      @logger.info("Creating subscription #{subscription}")
-      result = request(
-        :api_method => @pubsub.projects.subscriptions.create,
-        :parameters => {'name' => @subscription},
-        :body_object => {
-          :topic => @topic,
-          :ackDeadlineSeconds => 15
-        }
-      )
-      if result.error? and result.status != 409
-        raise Google::APIClient::ClientError, "Error #{result.status}: #{result.error_message}"
-      end
-      @subscription_exists = true
+    unless @subscription_exists
+      create_subscription
     end # if !@subscription
 
     @logger.info("Pulling messages from sub '#{subscription}'")
-    while !stop?
+    until stop?
       # Pull and queue messages
       messages = []
       result = request(
-        :api_method => @pubsub.projects.subscriptions.pull,
-        :parameters => {'subscription' => @subscription},
-        :body_object => {
-          :returnImmediately => false,
-          :maxMessages => @max_messages
+        api_method: @pubsub.projects.subscriptions.pull,
+        parameters: { 'subscription' => @subscription },
+        body_object: {
+          returnImmediately: false,
+          maxMessages: @max_messages
         }
       )
 
-      if !result.error?
-        messages = JSON.parse(result.body)
-        if messages.key?("receivedMessages")
-          messages = messages["receivedMessages"]
-        end
-      else
+      if result.error?
         @logger.info("Error pulling messages:'#{result.error_message}'")
+      else
+        messages = JSON.parse(result.body)
+        if messages.key?('receivedMessages')
+          messages = messages['receivedMessages']
+        end
       end
 
-      if messages
-        messages.each do |msg|
-          if msg.key?("message") and msg["message"].key?("data")
-            decoded_msg = Base64.decode64(msg["message"]["data"])
-            begin
-              parsed_msg = JSON.parse(decoded_msg)
-            rescue
-              parsed_msg = { :raw_message => decoded_msg }
-            end
-            event = LogStash::Event.new(parsed_msg)
-            decorate(event)
-            queue << event
-          end
-        end
+      next unless messages
 
-        ack_ids = messages.map{ |msg| msg["ackId"] }
-        result = request(
-          :api_method => @pubsub.projects.subscriptions.acknowledge,
-          :parameters => {'subscription' => @subscription},
-          :body_object => {
-            :ackIds => ack_ids
-          }
-        )
-        if result.error?
-          @logger.info("Error #{result.status}: #{result.error_message}")
+      messages.each do |msg|
+        next unless msg.key?('message') && msg['message'].key?('data')
+        decoded_msg = Base64.decode64(msg['message']['data'])
+        begin
+          parsed_msg = JSON.parse(decoded_msg)
+        rescue
+          parsed_msg = { raw_message: decoded_msg }
         end
-      end # if messages
+        event = LogStash::Event.new(parsed_msg)
+        decorate(event)
+        queue << event
+      end
+
+      ack_ids = messages.map { |msg| msg['ackId'] }
+      result = request(
+        api_method: @pubsub.projects.subscriptions.acknowledge,
+        parameters: { 'subscription' => @subscription },
+        body_object: {
+          ackIds: ack_ids
+        }
+      )
+      if result.error?
+        @logger.info("Error #{result.status}: #{result.error_message}")
+      end # if error
     end # loop
   end # def run
-end # class LogStash::Inputs::GooglePubSub
+end # class GooglePubSub

--- a/logstash-input-google_pubsub.gemspec
+++ b/logstash-input-google_pubsub.gemspec
@@ -1,26 +1,26 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-google_pubsub'
-  s.version = '0.9.0'
+  s.version = '0.9.1'
   s.licenses = ['Apache-2.0']
-  s.summary = "Logstash input plugin for Google Cloud Pub/Sub."
-  s.description = "This gem is a Logstash input plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program."
-  s.authors = ["Eric Johnson"]
+  s.summary = 'Logstash input plugin for Google Cloud Pub/Sub.'
+  s.description = 'This gem is a Logstash input plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program.'
+  s.authors = ['Eric Johnson']
   s.email = 'erjohnso@google.com'
-  s.homepage = "https://cloud.google.com/pubsub/overview"
-  s.require_paths = ["lib"]
+  s.homepage = 'https://cloud.google.com/pubsub/overview'
+  s.require_paths = ['lib']
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
-   # Tests
+  s.files = Dir['lib/**/*', 'spec/**/*', 'vendor/**/*', '*.gemspec', '*.md', 'CONTRIBUTORS', 'Gemfile', 'LICENSE', 'NOTICE.TXT']
+  # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Special flag to let us know this is actually a logstash plugin
-  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
+  s.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'input' }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
-  s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'stud', '>= 0.0.22'
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
+  s.add_runtime_dependency 'logstash-codec-plain', '~> 3'
+  s.add_runtime_dependency 'stud', '~> 0.0', '>= 0.0.22'
   # Google dependencies
   # google-api-client >= 0.9 requires ruby2 which is not currently compatible
   # with JRuby

--- a/spec/inputs/google_pubsub_spec.rb
+++ b/spec/inputs/google_pubsub_spec.rb
@@ -1,45 +1,43 @@
 # encoding: utf-8
-# Copyright 2016 Google Inc.                                                    
-#                                                                               
-# Licensed under the Apache License, Version 2.0 (the "License");               
-# you may not use this file except in compliance with the License.              
-# You may obtain a copy of the License at                                       
-#                                                                               
-#      http://www.apache.org/licenses/LICENSE-2.0                               
-#                                                                               
-# Unless required by applicable law or agreed to in writing, software           
-# distributed under the License is distributed on an "AS IS" BASIS,             
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.      
-# See the License for the specific language governing permissions and           
-# limitations under the License.                                                
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-require "logstash/devutils/rspec/spec_helper"
-require "logstash/inputs/google_pubsub"
+require 'logstash/devutils/rspec/spec_helper'
+require 'logstash/inputs/google_pubsub'
 
 describe LogStash::Inputs::GooglePubSub do
-
   let(:bad1) { { 'topic' => 'foo', 'subscription' => 'bar' } }
   let(:bad2) { { 'project_id' => 'foo', 'subscription' => 'bar' } }
   let(:bad3) { { 'project_id' => 'foo', 'topic' => 'bar' } }
   let(:config) { { 'project_id' => 'myproj', 'subscription' => 'foo', 'topic' => 'bar', 'json_key_file' => '/home/erjohnso/fake.json' } }
 
-  it "ensures required config options are present" do
-    expect {
-      plugin = LogStash::Inputs::GooglePubSub.new(bad1)
-    }.to raise_error(LogStash::ConfigurationError)
-    expect {
-      plugin = LogStash::Inputs::GooglePubSub.new(bad2)
-    }.to raise_error(LogStash::ConfigurationError)
-    expect {
-      plugin = LogStash::Inputs::GooglePubSub.new(bad3)
-    }.to raise_error(LogStash::ConfigurationError)
+  it 'ensures required config options are present' do
+    expect do
+      LogStash::Inputs::GooglePubSub.new(bad1)
+    end.to raise_error(LogStash::ConfigurationError)
+    expect do
+      LogStash::Inputs::GooglePubSub.new(bad2)
+    end.to raise_error(LogStash::ConfigurationError)
+    expect do
+      LogStash::Inputs::GooglePubSub.new(bad3)
+    end.to raise_error(LogStash::ConfigurationError)
   end
 
-  it "validates register vars" do
+  it 'validates register vars' do
     plugin = LogStash::Inputs::GooglePubSub.new(config)
     plugin.register
-    expect(plugin.topic).to eq("projects/myproj/topics/bar")
-    expect(plugin.subscription).to eq("projects/myproj/subscriptions/foo")
+    expect(plugin.topic).to eq('projects/myproj/topics/bar')
+    expect(plugin.subscription).to eq('projects/myproj/subscriptions/foo')
   end
-
 end


### PR DESCRIPTION
General idea is to depend on 'logstash-core-plugin-api' instead of 'logstash-core' to be compatible with logstash 5.x
I've done some rubocop cleanup and added Dockerfile for running this plugin in Docker + version bump.

Did not touch tests so far