### PR TITLE
Use codec to decode messages

### DIFF
--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -228,7 +228,6 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
     end # if !@subscription
 
     @logger.debug("Pulling messages from sub '#{subscription}'")
-    codec_instance = @codec.clone
     while !stop?
       # Pull and queue messages
       messages = []
@@ -254,7 +253,7 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
         messages.each do |msg|
           if msg.key?("message") and msg["message"].key?("data")
             decoded_msg = Base64.decode64(msg["message"]["data"])
-              codec_instance.decode(decoded_msg) do |event|
+            @codec.decode(decoded_msg) do |event|
               decorate(event)
               queue << event
             end

--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -228,6 +228,7 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
     end # if !@subscription
 
     @logger.debug("Pulling messages from sub '#{subscription}'")
+    codec_instance = @codec.clone
     while !stop?
       # Pull and queue messages
       messages = []
@@ -253,14 +254,10 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
         messages.each do |msg|
           if msg.key?("message") and msg["message"].key?("data")
             decoded_msg = Base64.decode64(msg["message"]["data"])
-            begin
-              parsed_msg = JSON.parse(decoded_msg)
-            rescue
-              parsed_msg = { :raw_message => decoded_msg }
+              codec_instance.decode(decoded_msg) do |event|
+              decorate(event)
+              queue << event
             end
-            event = LogStash::Event.new(parsed_msg)
-            decorate(event)
-            queue << event
           end
         end
 


### PR DESCRIPTION
For some reason this plugin assumes that data in the pubsub is always json. It is not possible to decode for example protobuf coming from pubsub.

Please have a look at the proposed fix. I have awareness that this is bc for most of the configs, since the plugin do json decoding by default.

I'm not sure but maybe additional change of `default :codec, "plain"` to `default :codec, "json"` would help here.

Just for completeness. This is logstash config that works for me (pubsub + protobuf) when that PR is applied:

```perl
input {
    google_pubsub {
        project_id => "xxxx"
        topic => "xxxx"
        subscription => "xxxx"
	codec => protobuf
	{
		class_name => "MyProtoClass"
		include_path => ['path_to_my_proto_class_pb.rb']
		protobuf_version_3 => true
	}
    }
}

output {
	stdout { codec => rubydebug }
}

```