### PR TITLE
Skip sending acks if ids are empty

### DIFF
--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -265,6 +265,8 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
         end
 
         ack_ids = messages.map{ |msg| msg["ackId"] }
+        next if ack_ids.empty?
+
         result = request(
           :api_method => @pubsub.projects.subscriptions.acknowledge,
           :parameters => {'subscription' => @subscription},


### PR DESCRIPTION
This is a low-touch fix for #14 where errors are being thrown because Pub/Sub doesn't expect acknowledge requests with an empty array of IDs. If accepted, it will invalidate PRs #22 and #18.

@jakelandis I'm tagging you because you were part of the review for #18 

I'm not doing any major refactoring because @rosbo and I are looking at moving this over to the Java API soon to follow suit with `logstash-output-google_bigquery` and `logstash-output-google_cloud_storage`.