### PR TITLE
Configuration item to include full message in metadata

### DIFF
--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -122,6 +122,38 @@ require "google/api_client"
 # output { stdout { codec => rubydebug } }
 # ----------------------------------
 #
+# ==== Metadata and Attributes
+# 
+# The original Pub/Sub message is preserved in the special Logstash 
+# `[@metadata][pubsub_message]` field so you can fetch:
+# 
+# * Message attributes
+# * The origiginal base64 data
+# * Pub/Sub message ID for de-duplication
+# * Publish time
+# 
+# You MUST extract any fields you want in a filter prior to the data being sent
+# to an output because Logstash deletes `@metadata` fields otherwise.
+# 
+# See the PubsubMessage
+# https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage[documentation]
+# for a full description of the fields.
+# 
+# Example to get the message ID:
+# 
+# [source,ruby]
+# ----------------------------------	
+# input {google_pubsub {...}}
+# 
+# filter {
+#   mutate {
+#     add_field => { "messageId" => "%{[@metadata][pubsub_message][messageId]}" }
+#   }
+# }
+# 
+# output {...}
+# ----------------------------------
+#
 class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
   config_name "google_pubsub"
 

--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -141,6 +141,9 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
   # specify a Service Account JSON key file.
   config :json_key_file, :validate => :path, :required => false
 
+  # If set true, will include the full message data in the `[@metadata][pubsub_message]` field.
+  config :include_metadata, :validate => :boolean, :required => false, :default => false
+
   # If undefined, Logstash will complain, even if codec is unused.
   default :codec, "plain"
 
@@ -254,6 +257,7 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
           if msg.key?("message") and msg["message"].key?("data")
             decoded_msg = Base64.decode64(msg["message"]["data"])
             @codec.decode(decoded_msg) do |event|
+              event.set("[@metadata][pubsub_message]", msg["message"]) if @include_metadata
               decorate(event)
               queue << event
             end


### PR DESCRIPTION
This adds the option to include a new metadata field as `[@metadata][pubsub_message]`. The field includes the full original message which allows for doing mutations. For example, we can grab the `messageId` and put it in a new field:

```
input {
    google_pubsub {
      project_id => "myproject-123456"
      topic => "mytopic"
      subscription => "mysub"
      codec => "json"
      include_metadata => true
    }
  }
filter {
  mutate {
    add_field => { "messageId" => "%{[@metadata][pubsub_message][messageId]}" }
  }
}
  output {
    elasticsearch {
      hosts => ["10.142.0.18"]
      index => "events-%{+YYYY.MM.dd}"
    }
  }
```

Alternatively, you can use `mutate` and `json` to output the entire message object:
```
input {
    google_pubsub {
      project_id => "myproject-123456"
      topic => "mytopic"
      subscription => "mysub"
      codec => "json"
      include_metadata => true
    }
  }
filter {
  mutate {
    add_field => { "pubsub" => "%{[@metadata][pubsub_message]}" }
  }
  json {
    source => "pubsub"
    target => "pubsub"
  }
}
  output {
    elasticsearch {
      hosts => ["10.142.0.18"]
      index => "events-%{+YYYY.MM.dd}"
    }
  }
```

For some reason, I couldn't get this to work with the filter just as:

```
filter {
  json {
    source => "%{[@metadata][pubsub_message]}"
    target => "pubsub"
  }
}
```

Even though it seems like that should be possible...

Closes #7.