### PR TITLE
Version 1.2.0 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+ - Change to Java client
+ - Add `create_subscription` setting. Fixes [#9](https://github.com/logstash-plugins/logstash-input-google_pubsub/issues/9)
+
 ## 1.1.0
   - Add additional attributes in the `[@metadata][pubsub_message]` field. Fixes [#7](https://github.com/logstash-plugins/logstash-input-google_pubsub/issues/7)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -259,6 +259,8 @@ If set true, will include the full message data in the `[@metadata][pubsub_messa
 [id="plugins-{type}s-{plugin}-create_subscription"]
 ===== `create_subscription`
 
+added[1.2.0]
+
   * Value type is <<boolean,boolean>>
   * Default value is `false`.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -133,6 +133,11 @@ input {
         # outside of GCE, you will need to specify the service account's
         # JSON key file below.
         #json_key_file => "/home/erjohnso/pkey.json"
+
+        # Should the plugin attempt to create the subscription on startup?
+        # This is not recommended for security reasons but may be useful in
+        # some cases.
+        #create_subscription => false
     }
 }
 output { stdout { codec => rubydebug } }

--- a/logstash-input-google_pubsub.gemspec
+++ b/logstash-input-google_pubsub.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-google_pubsub'
-  s.version         = '1.1.0'
+  s.version         = '1.2.0'
   s.licenses = ['Apache-2.0']
   s.summary = "Consume events from a Google Cloud PubSub service"
   s.description = "This gem is a Logstash input plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program."


### PR DESCRIPTION
Bump version to 1.2.0 after the Java migration and addition of `create_subscription`. Updated docs, version and CHANGELOG.

The builds seem to be broken in the same way across three of our repos now that were previously passing, it looks like someone changed something to private that the Logstash spec_helper requires.

 * https://travis-ci.org/logstash-plugins/logstash-input-google_pubsub/builds/374934287?utm_source=github_status&utm_medium=notification
 * https://travis-ci.org/logstash-plugins/logstash-output-google_bigquery
 * https://travis-ci.org/logstash-plugins/logstash-output-google_cloud_storage