### PR TITLE
Issue #34 Fix - Rollback Guava to v19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+ - Rollback Google Guava version to 19 to align with LogStash 6.2.4 Guava version. Fixes [#34](https://github.com/logstash-
+ plugins/logstash-input-google_pubsub/issues/34)
+ 
 ## 1.2.0
  - Change to Java client
  - Add `create_subscription` setting. Fixes [#9](https://github.com/logstash-plugins/logstash-input-google_pubsub/issues/9)

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile "org.json:json:20160810"
     compile "com.google.cloud:google-cloud-core:1.10.0"
     compile "io.netty:netty-codec-http2:4.1.16.Final"
-    compile "com.google.guava:guava:20.0"
+    compile "com.google.guava:guava:19.0"
     compile "com.google.cloud:google-cloud-core-grpc:1.10.0"
     compile "com.google.protobuf:protobuf-java:3.5.1"
     compile "com.google.api:gax:1.14.0"

--- a/logstash-input-google_pubsub.gemspec
+++ b/logstash-input-google_pubsub.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-google_pubsub'
-  s.version         = '1.2.0'
+  s.version         = '1.2.1'
   s.licenses = ['Apache-2.0']
   s.summary = "Consume events from a Google Cloud PubSub service"
   s.description = "This gem is a Logstash input plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program."
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.requirements << "jar 'com.google.cloud:google-cloud-pubsub', '0.28.0-beta'"
   s.requirements << "jar 'com.google.api.grpc:proto-google-cloud-pubsub-v1', '0.1.24'"
   s.requirements << "jar 'com.google.api:gax', '1.14.0'"
-  s.requirements << "jar 'com.google.guava:guava', '20.0'"
+  s.requirements << "jar 'com.google.guava:guava', '19.0'"
   s.requirements << "jar 'com.google.api:api-common', '1.2.0'"
   s.requirements << "jar 'com.google.auth:google-auth-library-oauth2-http', '0.9.0'"
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
As documented in Issue #34, the Guava version in 1.2.0 was set to 20. The problem is that LogStash 6.2.4's lib/ directory includes Guava 19. Thus, whenever this plugin is installed, a NoSuchMethodError is thrown on server startup (related to a Precondition.check() call being made).

By rolling back to Guava 19, this synchronizes the Guava between this plugin and LogStash 6.2.4.

I set gradle and the gem file to point to 19, and rolled the version to 1.2.1 with a pointer to Issue #34 in the change log.