### PR TITLE
Set default codec to json, update documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ and added to the processing pipeline queue. All Pub/Sub messages will be
 
 It is generally assumed that incoming messages will be in JSON and added to
 the logstash `event` as-is. However, if a plain text message is received, the
-plugin will return the raw text in as `raw_message` in the logstash `event`.
+plugin will return the raw text in as `raw_message` in the logstash `event`. If
+your default message type is other than JSON, you may specify it in the plugin
+configuration using the `codec` attribute.
 
 #### Authentication
 
@@ -101,6 +103,10 @@ input {
         # outside of GCE, you will need to specify the service account's
         # JSON key file below.
         #json_key_file => "/home/erjohnso/pkey.json"
+
+        # The default codec is json, specify an alternate if your events are
+        # formatted differently. See [here](https://www.elastic.co/guide/en/logstash/current/codec-plugins.html) for codec options.
+        # codec => json
     }
 }
 

--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -214,7 +214,7 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
   config :create_subscription, :validate => :boolean, :required => false, :default => false
 
   # If undefined, Logstash will complain, even if codec is unused.
-  default :codec, "plain"
+  default :codec, "json"
 
   public
   def register


### PR DESCRIPTION
Between versions `1.0.4` and `1.0.5`, [this commit](https://github.com/logstash-plugins/logstash-input-google_pubsub/commit/c60e0ae6ad36cf55026ca1a4cc6eff0f44872971) was added and
the [default codec](https://github.com/logstash-plugins/logstash-input-google_pubsub/blob/master/lib/logstash/inputs/google_pubsub.rb#L217) began to be respected. This results in json messages
being treated as `plain`, which wraps the consumed json event in the event's `message` field, and elasticsearch doesn't properly parse the event into fields.

This commit changes the default type to `json`, as that is the assumed default format anyway. Alternate codecs can be used by adding a codec attribute to the input plugin's configuration.