### PR TITLE
Bytearray Deserializer

### DIFF
--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -285,7 +285,6 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
 
   def extract_metadata(java_message)
     {
-      data: java_message.getData().toStringUtf8(),
       attributes: java_message.getAttributesMap(),
       messageId: java_message.getMessageId(),
       publishTime: Timestamps.toString(java_message.getPublishTime())

--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -216,6 +216,9 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
   # If undefined, Logstash will complain, even if codec is unused.
   default :codec, "plain"
 
+  # ByteArray Deserializer for binary codecs
+  config :bytearray_deserializer, :validate => :boolean, :required => false, :default => false
+
   public
   def register
     @logger.debug("Registering Google PubSub Input: project_id=#{@project_id}, topic=#{@topic}, subscription=#{@subscription}")
@@ -249,7 +252,11 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
     @logger.debug("Pulling messages from sub '#{@subscription_id}'")
     handler = MessageReceiver.new do |message|
       # handle incoming message, then ack/nack the received message
-      data = message.getData().toStringUtf8()
+      if @bytearray_deserializer
+        data = message.getData().toByteArray()
+      else
+        data = message.getData().toStringUtf8()
+      end
       @codec.decode(data) do |event|
         event.set("host", event.get("host") || @host)
         event.set("[@metadata][pubsub_message]", extract_metadata(message)) if @include_metadata

--- a/lib/logstash/inputs/google_pubsub.rb
+++ b/lib/logstash/inputs/google_pubsub.rb
@@ -258,7 +258,6 @@ class LogStash::Inputs::GooglePubSub < LogStash::Inputs::Base
         data = message.getData().toStringUtf8()
       end
       @codec.decode(data) do |event|
-        event.set("host", event.get("host") || @host)
         event.set("[@metadata][pubsub_message]", extract_metadata(message)) if @include_metadata
         decorate(event)
         queue << event

--- a/logstash-input-google_pubsub.gemspec
+++ b/logstash-input-google_pubsub.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-google_pubsub'
-  s.version         = '1.2.1'
+  s.version         = '1.2.1.1'
   s.licenses = ['Apache-2.0']
   s.summary = "Consume events from a Google Cloud PubSub service"
   s.description = "This gem is a Logstash input plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program."
@@ -29,6 +29,9 @@ Gem::Specification.new do |s|
   s.requirements << "jar 'com.google.guava:guava', '20.0'"
   s.requirements << "jar 'com.google.api:api-common', '1.2.0'"
   s.requirements << "jar 'com.google.auth:google-auth-library-oauth2-http', '0.9.0'"
+  s.requirements << "jar 'com.google.protobuf:protobuf-java', '3.6.0'"
+  s.requirements << "jar 'com.google.protobuf:protobuf-java-util', '3.6.0'"
+  s.requirements << "jar 'com.google.protobuf:protobuf-lite', '3.0.1'"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
 end

--- a/logstash-input-google_pubsub.gemspec
+++ b/logstash-input-google_pubsub.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
   s.requirements << "jar 'com.google.protobuf:protobuf-java-util', '3.6.0'"
   s.requirements << "jar 'com.google.protobuf:protobuf-lite', '3.0.1'"
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
+  s.add_development_dependency 'jar-dependencies', '~> 0.4.0'
 end


### PR DESCRIPTION
This PR add an option to deserialize messages as ByteArray for compatibility with binary codecs (avro, protobuf).

The use of ByteString.toStringUtf8 on message before the codec decode it tries to parse the string as UTF-8, but binary messages like protocol buffers messages are not valid UTF-8. They are binary data, and the UTF-8 mangling corrupts it and cause weird errors like "CodedInputStream encountered a malformed varint". Binary codecs expect message as ByteArray.
